### PR TITLE
Quate solution in re

### DIFF
--- a/single quate.ipynb
+++ b/single quate.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "String singleQuated1 = \"(?<!\\S)'[\\s\\S]*'(?!\\S)\";\n",
+    "#Assume that there is no character before and after single quate \n",
+    "#like 's , s after ' is not legal \n",
+    "\n",
+    "String singleQuated2 = \"(?<!s)'[\\s\\S]*'(?!s)\";\n",
+    "#Assume that there are only two conditions that we use single\n",
+    "#quate ('String' ans 's)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
String singleQuated1 = "(?<!\S)'[\s\S]*'(?!\S)";
#Assume that there is no character before and after single quate 
#like 's , s after ' is not legal 

String singleQuated2 = "(?<!s)'[\s\S]*'(?!s)";
#Assume that there are only two conditions that we use single
#quate ('String' ans 's)